### PR TITLE
Update eas-cli for submission

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -1,6 +1,6 @@
 {
   "cli": {
-    "version": ">= 16.15.0",
+    "version": ">= 16.10.0",
     "appVersionSource": "remote"
   },
   "build": {


### PR DESCRIPTION
Lower `eas.json` CLI version constraint to match the environment's `eas-cli` version and unblock submission.

---
<a href="https://cursor.com/background-agent?bcId=bc-695748af-f8c9-4065-9699-76d9c895a18b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-695748af-f8c9-4065-9699-76d9c895a18b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

